### PR TITLE
Add Metatron cube drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ El recorrido propuesto se inspira en la obra *Geometría Sagrada* y en la experi
 7. **Cubo de Metatrón** – integración final de las formas.
 
 Todas las fases cuentan ahora con dibujos animados básicos y la opción de cambiar el tema de colores.
+La séptima fase traza además las líneas entre los trece círculos para formar el Cubo de Metatrón.

--- a/script.js
+++ b/script.js
@@ -198,7 +198,50 @@ function drawDivineLine() {
 }
 
 function drawMetatron() {
-  // Por ahora reutilizamos la Flor de la Vida como base
-  drawFlowerOfLife();
-  // Se pueden añadir detalles adicionales en fases futuras
+  const centerX = canvas.width / 2;
+  const centerY = canvas.height / 2;
+  const r = 80;
+
+  const circles = [];
+  for (let i = 0; i < 6; i++) {
+    const angle = i * Math.PI / 3;
+    circles.push({
+      x: centerX + r * Math.cos(angle),
+      y: centerY + r * Math.sin(angle)
+    });
+  }
+  for (let i = 0; i < 6; i++) {
+    const angle = i * Math.PI / 3;
+    circles.push({
+      x: centerX + 2 * r * Math.cos(angle),
+      y: centerY + 2 * r * Math.sin(angle)
+    });
+  }
+  circles.push({ x: centerX, y: centerY });
+
+  let idx = 0;
+  function next() {
+    if (idx < circles.length) {
+      const c = circles[idx++];
+      animateCircle(c.x, c.y, r, 300, next);
+    } else {
+      drawConnections();
+    }
+  }
+
+  function drawConnections() {
+    for (let i = 0; i < circles.length; i++) {
+      for (let j = i + 1; j < circles.length; j++) {
+        animateLine(
+          circles[i].x,
+          circles[i].y,
+          circles[j].x,
+          circles[j].y,
+          200
+        );
+      }
+    }
+  }
+
+  next();
 }


### PR DESCRIPTION
## Summary
- animate the final Metatron cube phase with circles and connecting lines
- document the new Metatron cube drawing behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a9195ec488326a90c1ed64543e405